### PR TITLE
account manager의 get_queryset 메소드에 잘못 정의된 필터링 옵션 변경

### DIFF
--- a/accounts/managers.py
+++ b/accounts/managers.py
@@ -14,7 +14,7 @@ class UserManager(BaseUserManager):
     use_in_migrations = True
 
     def get_queryset(self):
-        return super().get_queryset().filter(is_delete=True)
+        return super().get_queryset().filter(is_delete=False)
 
     def create_user(self, username, email=None, password=None, **extra_fields):
         if not email:


### PR DESCRIPTION
## Description
account manager의 get_queryset메소드에서 is_delete=True인 항목만 필터링하도록 잘못된 옵션이 설정되어 있었습니다. 이제 is_delete=False인 항목만 필터링합니다.

## Related Issue
<!-- 이슈가 완벽히 해결된 경우에만 아래 줄에 현재 브런치의 이슈 번호를 입력해 주세요 -->
<!-- 이는 해당 브랜치를 삭제하고, 이슈를 닫을 것입니다 -->
<!-- 이슈 번호는 TG-숫자--issue-이슈번호의 양식을 따릅니다 -->
Closes #55 
