### PR TITLE
일반 로그인과 소셜 로그인 연동 구현

### DIFF
--- a/accounts/adapter.py
+++ b/accounts/adapter.py
@@ -7,6 +7,7 @@ try:
     from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
     from allauth.utils import valid_email_or_none
     from django.contrib.auth import get_user_model
+    from django.core.exceptions import ValidationError
 except ImportError:
     raise ImportError("allauth needs to be added to INSTALLED_APPS.")
 
@@ -18,6 +19,12 @@ class AccountAdapter(DefaultAccountAdapter):
     """
     Custom Account Adapter
     """
+
+    def clean_email(self, email):
+        email = super().clean_email(email)
+        if User.objects.filter(email=email).exists():
+            raise ValidationError("이미 사용 중인 이메일 주소입니다.")
+        return email
 
     def save_user(self, request, user, form, commit=True):
         """
@@ -61,8 +68,14 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
     """
 
     def pre_social_login(self, request, sociallogin):
-        # user_data = sociallogin.account.extra_data
-        pass
+        """
+        같은 이메일로 가입된 일반 계정이 존재하는 경우 소셜 로그인 계정을 연동합니다.
+        """
+        email = sociallogin.account.extra_data.get("email", None)
+        if email:
+            existing_user = User.objects.filter(email=email).first()
+            if existing_user:
+                sociallogin.connect(request, existing_user)
 
     def populate_user(self, request, sociallogin, data):
         """

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,6 +1,7 @@
 from accounts.views import *
 
 try:
+    from allauth.socialaccount.views import signup
     from dj_rest_auth.app_settings import api_settings
     from dj_rest_auth.views import (
         LoginView,
@@ -24,17 +25,18 @@ urlpatterns = [
     path("users/", include(router.urls), name="user"),
 ]
 
-# dj-rest-auth urls(일부만 사용)
+# allauth, dj-rest-auth urls(일부만 사용)
 urlpatterns += [
     path("password/reset/", PasswordResetView.as_view(), name="rest_password_reset"),
     path("password/reset/confirm/", PasswordResetConfirmView.as_view(), name="rest_password_reset_confirm"),
     path("password/change/", PasswordChangeView.as_view(), name="rest_password_change"),
     path("login/", LoginView.as_view(), name="rest_login"),
     path("logout/", LogoutView.as_view(), name="rest_logout"),
+    path("social/signup/", signup, name="socialaccount_signup"),
     path("registration/", include("dj_rest_auth.registration.urls")),
 ]
 
-# JWT 사용 시 추가
+# SimpleJWT
 if api_settings.USE_JWT:
     from dj_rest_auth.jwt_auth import get_refresh_view
     from rest_framework_simplejwt.views import TokenVerifyView

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -288,6 +288,7 @@ SIMPLE_JWT = {
 ACCOUNT_ADAPTER = "accounts.adapter.AccountAdapter"
 SOCIALACCOUNT_ADAPTER = "accounts.adapter.SocialAccountAdapter"
 AUTH_USER_MODEL = "accounts.User"  # Change Default User Model
+SOCIALACCOUNT_AUTO_SIGNUP = True  # 자동 소셜 로그인 가입
 ACCOUNT_EMAIL_REQUIRED = True  # email 필드 사용 o
 ACCOUNT_AUTHENTICATION_METHOD = "email"  # 인증 메소드
 ACCOUNT_EMAIL_VERIFICATION = "none"  # email 인증 안함 사용하는 경우 mandatory


### PR DESCRIPTION
## Description
일반 로그인 유저가 가입된 이메일과 동일한 이메일로 소셜 로그인 시, 소셜 계정 연동
소셜 로그인 유저가 같은 이메일로 일반 회원가입 진행 시 400에러와 함께 중복 이메일 에러라는 간단한 응답 발생(409에러를 주기 위해서는 커스텀이 많이 필요해 Robust성이 보장되지 않을 수 있어 미구현)

## Related Issue
<!-- 이슈가 완벽히 해결된 경우에만 아래 줄에 현재 브런치의 이슈 번호를 입력해 주세요 -->
<!-- 이는 해당 브랜치를 삭제하고, 이슈를 닫을 것입니다 -->
<!-- 이슈 번호는 TG-숫자--issue-이슈번호의 양식을 따릅니다 -->
Closes #81 
